### PR TITLE
Amend

### DIFF
--- a/src/main/java/server/constants/FormatHelpers.java
+++ b/src/main/java/server/constants/FormatHelpers.java
@@ -1,0 +1,7 @@
+package server.constants;
+
+public class FormatHelpers {
+    public final static String SPACE = " ";
+    public final static String CRLF = "\r\n";
+    public final static String COLON = ": ";
+}

--- a/src/main/java/server/constants/Method.java
+++ b/src/main/java/server/constants/Method.java
@@ -1,4 +1,4 @@
-package server.request;
+package server.constants;
 
 public enum Method {
     GET,

--- a/src/main/java/server/constants/Path.java
+++ b/src/main/java/server/constants/Path.java
@@ -1,0 +1,20 @@
+package server.constants;
+
+public enum Path {
+    SIMPLE_GET("/simple_get"),
+    GET_WITH_BODY("/get_with_body"),
+    OPTIONS_ONE("/method_options"),
+    OPTIONS_TWO("/method_options2"),
+    ECHO_BODY("/echo_body"),
+    REDIRECT("/redirect"),;
+
+    public final String path;
+
+    Path(String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+}

--- a/src/main/java/server/constants/Protocol.java
+++ b/src/main/java/server/constants/Protocol.java
@@ -1,0 +1,15 @@
+package server.constants;
+
+public enum Protocol {
+    _1_1("HTTP/1.1");
+
+    private final String version;
+
+    Protocol(String version) {
+        this.version = version;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/src/main/java/server/constants/StatusCode.java
+++ b/src/main/java/server/constants/StatusCode.java
@@ -1,4 +1,4 @@
-package server.response;
+package server.constants;
 
 public enum StatusCode {
     _200("200 OK"),

--- a/src/main/java/server/request/Request.java
+++ b/src/main/java/server/request/Request.java
@@ -1,10 +1,8 @@
 package server.request;
 
-import server.helper.ControlCharacter;
+import static server.constants.FormatHelpers.*;
 
 public class Request {
-    private String CRLF = new ControlCharacter().CRLF();
-    private String space = new ControlCharacter().space();
     private String[] headerBodyStrings;
     private String method;
     private String path;
@@ -64,7 +62,7 @@ public class Request {
     }
 
     private void splitFirstLineOfHeader(String firstLine) {
-        String[] splitMethodPath = firstLine.split(space);
+        String[] splitMethodPath = firstLine.split(SPACE);
         setMethod(splitMethodPath[0]);
         setPath(splitMethodPath[1]);
     }

--- a/src/main/java/server/response/Response.java
+++ b/src/main/java/server/response/Response.java
@@ -1,19 +1,17 @@
 package server.response;
 
-import server.helper.*;
+import server.constants.Protocol;
+
+import static server.constants.FormatHelpers.*;
 
 public class Response {
-    private ControlCharacter character = new ControlCharacter();
-    private String CRLF = character.CRLF();
     private String statusLine;
     private String headers;
     private String body;
 
     public Response setStatusLine(StatusCode statusCode) {
         String protocol = Protocol._1_1.getVersion();
-        String space = character.space();
-
-        this.statusLine = protocol + space + statusCode.getMessage() + CRLF;
+        this.statusLine = protocol + SPACE + statusCode.getMessage() + CRLF;
         return this;
     }
 
@@ -36,8 +34,7 @@ public class Response {
     }
 
     private String formatHeaders(String name, String value) {
-        String separator = character.separator();
-        StringBuilder headers = new StringBuilder().append(name).append(separator).append(value).append(CRLF);
+        StringBuilder headers = new StringBuilder().append(name).append(COLON).append(value).append(CRLF);
 
         return headers.toString();
     }

--- a/src/main/java/server/response/Response.java
+++ b/src/main/java/server/response/Response.java
@@ -1,6 +1,7 @@
 package server.response;
 
 import server.constants.Protocol;
+import server.constants.StatusCode;
 
 import static server.constants.FormatHelpers.*;
 

--- a/src/main/java/server/response/ResponseBuilder.java
+++ b/src/main/java/server/response/ResponseBuilder.java
@@ -1,5 +1,7 @@
 package server.response;
 
+import server.constants.StatusCode;
+
 public class ResponseBuilder {
     public Response build(StatusCode statusCode, String headerName, String headerValue, String body) {
         return new Response()

--- a/src/main/java/server/routing/Config.java
+++ b/src/main/java/server/routing/Config.java
@@ -1,6 +1,7 @@
 package server.routing;
 
-import server.request.Method;
+import server.constants.StatusCode;
+import server.constants.Method;
 import server.response.*;
 
 public class Config {

--- a/src/main/java/server/routing/Config.java
+++ b/src/main/java/server/routing/Config.java
@@ -1,34 +1,32 @@
 package server.routing;
 
-import server.constants.Path;
-import server.constants.StatusCode;
-import server.constants.Method;
+import server.constants.*;
 import server.response.*;
 
 public class Config {
     public Routes setRoutes() {
         return new Routes()
-                .add(routeWithDefaultHandler(Method.GET, Path.SIMPLE_GET.getPath()))
-                .add(routeWithDefaultHandler(Method.HEAD, Path.SIMPLE_GET.getPath()))
-                .add(routeWithDefaultHandler(Method.HEAD, Path.GET_WITH_BODY.getPath()))
-                .add(routeWithDefaultHandler(Method.OPTIONS, Path.GET_WITH_BODY.getPath()))
-                .add(routeWithDefaultHandler(Method.GET, Path.OPTIONS_ONE.getPath()))
-                .add(routeWithDefaultHandler(Method.HEAD, Path.OPTIONS_ONE.getPath()))
-                .add(routeWithDefaultHandler(Method.OPTIONS, Path.OPTIONS_ONE.getPath()))
-                .add(routeWithDefaultHandler(Method.GET, Path.OPTIONS_TWO.getPath()))
-                .add(routeWithDefaultHandler(Method.HEAD, Path.OPTIONS_TWO.getPath()))
-                .add(routeWithDefaultHandler(Method.OPTIONS, Path.OPTIONS_TWO.getPath()))
-                .add(routeWithDefaultHandler(Method.PUT, Path.OPTIONS_TWO.getPath()))
-                .add(routeWithDefaultHandler(Method.POST, Path.OPTIONS_TWO.getPath()))
-                .add(routeWithDefaultHandler(Method.POST, Path.ECHO_BODY.getPath()))
-                .add(routeWithRedirectHandler(Method.GET, Path.REDIRECT.getPath()));
+                .add(routeWithDefaultHandler(Method.GET, Path.SIMPLE_GET))
+                .add(routeWithDefaultHandler(Method.HEAD, Path.SIMPLE_GET))
+                .add(routeWithDefaultHandler(Method.HEAD, Path.GET_WITH_BODY))
+                .add(routeWithDefaultHandler(Method.OPTIONS, Path.GET_WITH_BODY))
+                .add(routeWithDefaultHandler(Method.GET, Path.OPTIONS_ONE))
+                .add(routeWithDefaultHandler(Method.HEAD, Path.OPTIONS_ONE))
+                .add(routeWithDefaultHandler(Method.OPTIONS, Path.OPTIONS_ONE))
+                .add(routeWithDefaultHandler(Method.GET, Path.OPTIONS_TWO))
+                .add(routeWithDefaultHandler(Method.HEAD, Path.OPTIONS_TWO))
+                .add(routeWithDefaultHandler(Method.OPTIONS, Path.OPTIONS_TWO))
+                .add(routeWithDefaultHandler(Method.PUT, Path.OPTIONS_TWO))
+                .add(routeWithDefaultHandler(Method.POST, Path.OPTIONS_TWO))
+                .add(routeWithDefaultHandler(Method.POST, Path.ECHO_BODY))
+                .add(routeWithRedirectHandler(Method.GET, Path.REDIRECT));
     }
 
-    private Route routeWithDefaultHandler(Method method, String path) {
+    private Route routeWithDefaultHandler(Method method, Path path) {
         return RouteBuilder.build(method, path, (request) -> new ResponseBuilder().build(StatusCode._200, null, null, request.getBody()));
     }
 
-    private Route routeWithRedirectHandler(Method method, String path) {
+    private Route routeWithRedirectHandler(Method method, Path path) {
         String scheme = "http";
         String redirectTo = Path.SIMPLE_GET.getPath();
         return RouteBuilder.build(method, path, (request) -> new ResponseBuilder().build(StatusCode._301, "Location", new URL(scheme, request.getHost(), redirectTo).build(), request.getBody()));

--- a/src/main/java/server/routing/Config.java
+++ b/src/main/java/server/routing/Config.java
@@ -1,5 +1,6 @@
 package server.routing;
 
+import server.constants.Path;
 import server.constants.StatusCode;
 import server.constants.Method;
 import server.response.*;
@@ -7,20 +8,20 @@ import server.response.*;
 public class Config {
     public Routes setRoutes() {
         return new Routes()
-                .add(routeWithDefaultHandler(Method.GET, "/simple_get"))
-                .add(routeWithDefaultHandler(Method.HEAD, "/simple_get"))
-                .add(routeWithDefaultHandler(Method.HEAD, "/get_with_body"))
-                .add(routeWithDefaultHandler(Method.OPTIONS, "/get_with_body"))
-                .add(routeWithDefaultHandler(Method.GET, "/method_options"))
-                .add(routeWithDefaultHandler(Method.HEAD, "/method_options"))
-                .add(routeWithDefaultHandler(Method.OPTIONS, "/method_options"))
-                .add(routeWithDefaultHandler(Method.GET, "/method_options2"))
-                .add(routeWithDefaultHandler(Method.HEAD, "/method_options2"))
-                .add(routeWithDefaultHandler(Method.OPTIONS, "/method_options2"))
-                .add(routeWithDefaultHandler(Method.PUT, "/method_options2"))
-                .add(routeWithDefaultHandler(Method.POST, "/method_options2"))
-                .add(routeWithDefaultHandler(Method.POST, "/echo_body"))
-                .add(routeWithRedirectHandler(Method.GET, "/redirect"));
+                .add(routeWithDefaultHandler(Method.GET, Path.SIMPLE_GET.getPath()))
+                .add(routeWithDefaultHandler(Method.HEAD, Path.SIMPLE_GET.getPath()))
+                .add(routeWithDefaultHandler(Method.HEAD, Path.GET_WITH_BODY.getPath()))
+                .add(routeWithDefaultHandler(Method.OPTIONS, Path.GET_WITH_BODY.getPath()))
+                .add(routeWithDefaultHandler(Method.GET, Path.OPTIONS_ONE.getPath()))
+                .add(routeWithDefaultHandler(Method.HEAD, Path.OPTIONS_ONE.getPath()))
+                .add(routeWithDefaultHandler(Method.OPTIONS, Path.OPTIONS_ONE.getPath()))
+                .add(routeWithDefaultHandler(Method.GET, Path.OPTIONS_TWO.getPath()))
+                .add(routeWithDefaultHandler(Method.HEAD, Path.OPTIONS_TWO.getPath()))
+                .add(routeWithDefaultHandler(Method.OPTIONS, Path.OPTIONS_TWO.getPath()))
+                .add(routeWithDefaultHandler(Method.PUT, Path.OPTIONS_TWO.getPath()))
+                .add(routeWithDefaultHandler(Method.POST, Path.OPTIONS_TWO.getPath()))
+                .add(routeWithDefaultHandler(Method.POST, Path.ECHO_BODY.getPath()))
+                .add(routeWithRedirectHandler(Method.GET, Path.REDIRECT.getPath()));
     }
 
     private Route routeWithDefaultHandler(Method method, String path) {
@@ -29,7 +30,7 @@ public class Config {
 
     private Route routeWithRedirectHandler(Method method, String path) {
         String scheme = "http";
-        String redirectTo = "/simple_get";
+        String redirectTo = Path.SIMPLE_GET.getPath();
         return RouteBuilder.build(method, path, (request) -> new ResponseBuilder().build(StatusCode._301, "Location", new URL(scheme, request.getHost(), redirectTo).build(), request.getBody()));
     }
 }

--- a/src/main/java/server/routing/Route.java
+++ b/src/main/java/server/routing/Route.java
@@ -1,6 +1,6 @@
 package server.routing;
 
-import server.request.Method;
+import server.constants.Method;
 
 public class Route {
     private Method requestMethod;

--- a/src/main/java/server/routing/Route.java
+++ b/src/main/java/server/routing/Route.java
@@ -1,6 +1,6 @@
 package server.routing;
 
-import server.constants.Method;
+import server.constants.*;
 
 public class Route {
     private Method requestMethod;
@@ -12,8 +12,8 @@ public class Route {
         return this;
     }
 
-    public Route setRequestPath(String path) {
-        this.requestPath = path;
+    public Route setRequestPath(Path path) {
+        this.requestPath = path.getPath();
         return this;
     }
 

--- a/src/main/java/server/routing/RouteBuilder.java
+++ b/src/main/java/server/routing/RouteBuilder.java
@@ -1,9 +1,10 @@
 package server.routing;
 
 import server.constants.Method;
+import server.constants.Path;
 
 public class RouteBuilder {
-    public static Route build(Method requestMethod, String requestPath, RequestHandler handler) {
+    public static Route build(Method requestMethod, Path requestPath, RequestHandler handler) {
          return new Route()
                  .setRequestMethod(requestMethod)
                  .setRequestPath(requestPath)

--- a/src/main/java/server/routing/RouteBuilder.java
+++ b/src/main/java/server/routing/RouteBuilder.java
@@ -1,6 +1,6 @@
 package server.routing;
 
-import server.request.Method;
+import server.constants.Method;
 
 public class RouteBuilder {
     public static Route build(Method requestMethod, String requestPath, RequestHandler handler) {

--- a/src/main/java/server/routing/RouteHandler.java
+++ b/src/main/java/server/routing/RouteHandler.java
@@ -74,7 +74,7 @@ public class RouteHandler {
     }
 
     private boolean isHeadRequest(Request request) {
-        return Method.OPTIONS.toString().equalsIgnoreCase(request.getMethod());
+        return Method.HEAD.toString().equalsIgnoreCase(request.getMethod());
     }
 
     private Response buildHeadResponse() {

--- a/src/main/java/server/routing/RouteHandler.java
+++ b/src/main/java/server/routing/RouteHandler.java
@@ -1,5 +1,7 @@
 package server.routing;
 
+import server.constants.Method;
+import server.constants.StatusCode;
 import server.request.*;
 import server.response.*;
 

--- a/src/main/java/server/routing/Routes.java
+++ b/src/main/java/server/routing/Routes.java
@@ -1,6 +1,6 @@
 package server.routing;
 
-import server.request.Method;
+import server.constants.Method;
 
 import java.util.*;
 

--- a/src/test/java/server/response/ResponseBuilderTest.java
+++ b/src/test/java/server/response/ResponseBuilderTest.java
@@ -1,8 +1,8 @@
 package server.response;
 
 import org.junit.Test;
+import server.constants.StatusCode;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.*;
 
 public class ResponseBuilderTest {

--- a/src/test/java/server/response/ResponseTest.java
+++ b/src/test/java/server/response/ResponseTest.java
@@ -1,6 +1,7 @@
 package server.response;
 
 import org.junit.*;
+import server.constants.StatusCode;
 
 import static org.junit.Assert.*;
 

--- a/src/test/java/server/routing/RouteBuilderTest.java
+++ b/src/test/java/server/routing/RouteBuilderTest.java
@@ -1,7 +1,7 @@
 package server.routing;
 
 import org.junit.*;
-import server.request.Method;
+import server.constants.Method;
 
 import static org.junit.Assert.*;
 

--- a/src/test/java/server/routing/RouteBuilderTest.java
+++ b/src/test/java/server/routing/RouteBuilderTest.java
@@ -1,7 +1,7 @@
 package server.routing;
 
 import org.junit.*;
-import server.constants.Method;
+import server.constants.*;
 
 import static org.junit.Assert.*;
 
@@ -9,7 +9,7 @@ public class RouteBuilderTest {
     @Test
     public void buildsANewRouteSetWithGivenValues() {
         Method requestMethod = Method.GET;
-        String requestPath = "/hello";
+        String requestPath = Path.SIMPLE_GET.getPath();
         RequestHandler handler = request -> null;
 
         Route route = RouteBuilder.build(requestMethod, requestPath, handler);

--- a/src/test/java/server/routing/RouteBuilderTest.java
+++ b/src/test/java/server/routing/RouteBuilderTest.java
@@ -9,13 +9,13 @@ public class RouteBuilderTest {
     @Test
     public void buildsANewRouteSetWithGivenValues() {
         Method requestMethod = Method.GET;
-        String requestPath = Path.SIMPLE_GET.getPath();
+        Path requestPath = Path.SIMPLE_GET;
         RequestHandler handler = request -> null;
 
         Route route = RouteBuilder.build(requestMethod, requestPath, handler);
 
         assertEquals(requestMethod, route.getRequestMethod());
-        assertEquals(requestPath, route.getRequestPath());
+        assertEquals(requestPath.getPath(), route.getRequestPath());
         assertEquals(handler, route.getHandler());
     }
 }

--- a/src/test/java/server/routing/RouteHandlerTest.java
+++ b/src/test/java/server/routing/RouteHandlerTest.java
@@ -1,6 +1,7 @@
 package server.routing;
 
 import org.junit.*;
+import server.constants.StatusCode;
 import server.request.Request;
 import server.response.*;
 

--- a/src/test/java/server/routing/RoutesTest.java
+++ b/src/test/java/server/routing/RoutesTest.java
@@ -1,8 +1,7 @@
 package server.routing;
 
 import org.junit.*;
-import server.constants.StatusCode;
-import server.constants.Method;
+import server.constants.*;
 import server.response.*;
 
 import java.util.*;

--- a/src/test/java/server/routing/RoutesTest.java
+++ b/src/test/java/server/routing/RoutesTest.java
@@ -13,7 +13,6 @@ public class RoutesTest {
     private MockRequestHandler requestHandler;
     private Map<String, ArrayList<Route>> allRoutesAndPaths;
     private List<Route> routesForSinglePath;
-    private String fakePath = "/a_path";
 
     @Before
     public void setUp() {
@@ -24,68 +23,77 @@ public class RoutesTest {
 
     @Test
     public void addsANewRouteWhenThePathDoesNotExist() {
-        Route mockRoute1 = RouteBuilder.build(Method.GET, fakePath, requestHandler);
+        Route mockRoute1 = RouteBuilder.build(Method.GET, Path.SIMPLE_GET, requestHandler);
 
         routes.add(mockRoute1);
 
+        String path = Path.SIMPLE_GET.getPath();
         allRoutesAndPaths = routes.getAllPathsAndRoutes();
 
-        assertTrue(allRoutesAndPaths.containsKey(fakePath));
+        assertTrue(allRoutesAndPaths.containsKey(path));
         assertEquals(1, allRoutesAndPaths.size());
     }
 
     @Test
     public void addsARouteToAnExistingPath() {
-        Route mockRoute1 = RouteBuilder.build(Method.GET, fakePath, requestHandler);
-        Route mockRoute2 = RouteBuilder.build(Method.OPTIONS, fakePath, requestHandler);
+        Route mockRoute1 = RouteBuilder.build(Method.GET, Path.SIMPLE_GET, requestHandler);
+        Route mockRoute2 = RouteBuilder.build(Method.OPTIONS, Path.SIMPLE_GET, requestHandler);
 
         routes.add(mockRoute1);
         routes.add(mockRoute2);
 
-        allRoutesAndPaths = routes.getAllPathsAndRoutes();
-        routesForSinglePath = routes.getRoutesForPath(fakePath);
+        String path = Path.SIMPLE_GET.getPath();
 
-        assertTrue(allRoutesAndPaths.containsKey(fakePath));
+        allRoutesAndPaths = routes.getAllPathsAndRoutes();
+        routesForSinglePath = routes.getRoutesForPath(path);
+
+        assertTrue(allRoutesAndPaths.containsKey(path));
         assertEquals(1, allRoutesAndPaths.size());
         assertEquals(2, routesForSinglePath.size());
     }
 
     @Test
     public void doesNotAddARouteIfItAlreadyExists() {
-        Route mockRoute1 = RouteBuilder.build(Method.GET, fakePath, requestHandler);
-        Route mockRoute2 = RouteBuilder.build(Method.OPTIONS, fakePath, requestHandler);
-        Route mockRoute3 = RouteBuilder.build(Method.OPTIONS, fakePath, requestHandler);
+        Route mockRoute1 = RouteBuilder.build(Method.GET, Path.SIMPLE_GET, requestHandler);
+        Route mockRoute2 = RouteBuilder.build(Method.OPTIONS, Path.SIMPLE_GET, requestHandler);
+        Route mockRoute3 = RouteBuilder.build(Method.OPTIONS, Path.SIMPLE_GET, requestHandler);
 
         routes.add(mockRoute1);
         routes.add(mockRoute2);
         routes.add(mockRoute3);
 
-        allRoutesAndPaths = routes.getAllPathsAndRoutes();
-        routesForSinglePath = routes.getRoutesForPath(fakePath);
+        String path = Path.SIMPLE_GET.getPath();
 
-        assertTrue(allRoutesAndPaths.containsKey(fakePath));
+        allRoutesAndPaths = routes.getAllPathsAndRoutes();
+        routesForSinglePath = routes.getRoutesForPath(path);
+
+        assertTrue(allRoutesAndPaths.containsKey(path));
         assertEquals(1, allRoutesAndPaths.size());
         assertEquals(2, routesForSinglePath.size());
     }
 
     @Test
     public void returnsASingleRoute() {
-        Route mockRoute1 = RouteBuilder.build(Method.GET, fakePath, requestHandler);
+        Route mockRoute1 = RouteBuilder.build(Method.GET, Path.SIMPLE_GET, requestHandler);
 
         routes.add(mockRoute1);
 
-        assertEquals(mockRoute1, routes.getASingleRoute(fakePath, Method.GET.toString()));
+        String path = Path.SIMPLE_GET.getPath();
+        String method = Method.GET.toString();
+
+        assertEquals(mockRoute1, routes.getASingleRoute(path, method));
     }
 
     @Test
     public void knowsTheValidMethodsForAPath() {
-        Route mockRoute1 = RouteBuilder.build(Method.GET, fakePath, requestHandler);
-        Route mockRoute2 = RouteBuilder.build(Method.OPTIONS, fakePath, requestHandler);
+        Route mockRoute1 = RouteBuilder.build(Method.GET, Path.SIMPLE_GET, requestHandler);
+        Route mockRoute2 = RouteBuilder.build(Method.OPTIONS, Path.SIMPLE_GET, requestHandler);
 
         routes.add(mockRoute1);
         routes.add(mockRoute2);
 
-        List<String> validMethods = routes.getMethodsForPath(fakePath);
+        String path = Path.SIMPLE_GET.getPath();
+        List<String> validMethods = routes.getMethodsForPath(path);
 
         assertTrue(validMethods.contains("GET"));
         assertTrue(validMethods.contains("OPTIONS"));

--- a/src/test/java/server/routing/RoutesTest.java
+++ b/src/test/java/server/routing/RoutesTest.java
@@ -1,7 +1,8 @@
 package server.routing;
 
 import org.junit.*;
-import server.request.Method;
+import server.constants.StatusCode;
+import server.constants.Method;
 import server.response.*;
 
 import java.util.*;


### PR DESCRIPTION
- renames `helper` package to `constants`
- renames ControlCharacters to FormatHelpers
- imports format helpers (e.g. CRLF, SPCE) as static fields
- moves enum classes to constants package
- creates enum for request paths
- uses path enum to configure valid routes

fixes error : isHeadRequest asserts on correct value